### PR TITLE
Remove upper version constraints for dependencies, remove upper boundaries from deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,17 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "librosa>=0.10.1,<0.12.0",
-    "numpy>=1.26.4,<2.4.0",
-    "scikit-learn>=1.4.2,<1.8.0",
-    "scipy>=1.13,<1.17",
-    "setuptools>=69.2,<80.10",
+    "librosa>=0.10.1",
+    "numpy>=1.26.4",
+    "scikit-learn>=1.4.2",
+    "scipy>=1.13",
+    "setuptools>=69.2",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "soundfile>=0.12.1,<0.14.0",
-    "pytest>=8.1.1,<9.1.0",
+    "soundfile>=0.12.1",
+    "pytest>=8.1.1",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-soundfile>=0.12.1,<0.14.0
-pytest>=8.1.1,<9.1.0
+soundfile>=0.12.1
+pytest>=8.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-setuptools>=69.2,<80.10
-librosa>=0.10.1,<0.12.0
-numpy>=1.26.4,<2.4.0
-scipy>=1.13,<1.17
-scikit-learn>=1.4.2,<1.8.0
+setuptools>=69.2
+librosa>=0.10.1
+numpy>=1.26.4
+scipy>=1.13
+scikit-learn>=1.4.2

--- a/test-and-mark.ps1
+++ b/test-and-mark.ps1
@@ -23,7 +23,7 @@ if (Test-Path $activate) {
     if ($LASTEXITCODE -ne 0) { throw "Failed to install development dependencies." }
 }
 
-pip install -r requirements-dev.txt
+pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt
 if ($LASTEXITCODE -ne 0) { throw "Failed to install development dependencies." }
 
 pytest


### PR DESCRIPTION
This pull request primarily updates the project's dependency management by relaxing upper version constraints on both core and development dependencies. It also improves the installation process for development dependencies to ensure the latest compatible versions are used.

Dependency management updates:

* Removed upper version limits from core dependencies in `pyproject.toml`, allowing installation of newer versions of `librosa`, `numpy`, `scikit-learn`, `scipy`, and `setuptools`.
* Removed upper version limits from development dependencies in both `pyproject.toml` and `requirements-dev.txt`, affecting `soundfile` and `pytest`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L20-R30) [[2]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL2-R3)

Development workflow improvement:

* Updated the `test-and-mark.ps1` script to use `pip install --upgrade --upgrade-strategy eager` for installing development dependencies, ensuring the latest compatible versions are installed.